### PR TITLE
Resolve invalid UUID generation

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,7 +38,7 @@ fi
 
 # Update SSL port configuration if it does'nt exists
 #
-UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+UUID="$(cat /dev/urandom | tr -dc 'a-zA-Z' | fold -w 1 | head -n 1)$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 7 | head -n 1)"
 VAR=$(cat conf/server.xml | grep "$CATALINA_HOME/.keystore")
 
 if [ -f $CATALINA_HOME/.keystore ] && [ -z $VAR ]; then


### PR DESCRIPTION
Issue #6

UUIDs were generated using a random set of alphanumeric characters.
This resulted in times when the UUID began with a number. Since the
UUID is used as an element in the server.xml file, when this
occurred, xmlstarlet would fail complaining that the UUID was not
a valid XML element. This patch ensures that the first character of
the generated UUID is always an alpha character. The others should
remain alphanumeric.