### PR TITLE
Bump version 9.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:8-jre8
 
 LABEL maintainer="Florian JUDITH <florian.judith.b@gmail.com>"
 
-ENV VERSION=9.0.8
+ENV VERSION=9.1.2
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends openjdk-8-jdk ant git patch xmlstarlet certbot

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Supported tags and respective Dockerfile links
 
-[`9.0.8`, `latest`](https://github.com/fjudith/docker-draw.io/tree/9.0.8)
+[`9.1.2`, `latest`](https://github.com/fjudith/docker-draw.io/tree/9.1.2)
 
 # Introduction
 


### PR DESCRIPTION
Bump the version of the used draw.io.

See https://github.com/jgraph/drawio/blob/master/ChangeLog