### PR TITLE
Change the tomcat and java version, use slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8-jre8
+FROM tomcat:9-jre10-slim
 
 LABEL maintainer="Florian JUDITH <florian.judith.b@gmail.com>"
 
@@ -6,7 +6,7 @@ ENV VERSION=9.1.6
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
-        openjdk-8-jdk ant git patch xmlstarlet certbot && \
+        openjdk-10-jdk-headless ant git patch wget xmlstarlet certbot && \
     cd /tmp && \
     wget https://github.com/jgraph/draw.io/archive/v${VERSION}.zip && \
     unzip v${VERSION}.zip && \
@@ -15,7 +15,7 @@ RUN apt-get update -y && \
     ant war && \
     cd /tmp/drawio-${VERSION}/build && \
     unzip /tmp/drawio-${VERSION}/build/draw.war -d $CATALINA_HOME/webapps/draw && \
-    apt-get remove -y --purge openjdk-8-jdk ant git patch && \
+    apt-get remove -y --purge openjdk-10-jdk-headless ant git patch wget && \
     apt-get autoremove -y --purge && \
     apt-get clean && \
     rm -r /var/lib/apt/lists/* && \


### PR DESCRIPTION
This changes the base image to tomcat9-jre10-slim. Besides a bump in the
tomcat- and jre-version the resulting image is a lot smaller due to the
-slim version. As of now its 483MB instead of 787MB.