### PR TITLE
Bump version 9.4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Supported tags and respective Dockerfile links
 
-[`9.4.6`, `latest`](https://github.com/fjudith/docker-draw.io/tree/9.4.6)
+[`9.4.7`, `latest`](https://github.com/fjudith/docker-draw.io/tree/9.4.7)
 
 # Introduction
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:9-jre8-alpine
 
 LABEL maintainer="Florian JUDITH <florian.judith.b@gmail.com>"
 
-ARG VERSION=9.4.6
+ARG VERSION=9.4.7
 
 RUN apk add \
     openjdk8 apache-ant git patch xmlstarlet certbot curl && \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -2,7 +2,7 @@ FROM tomcat:9-jre10-slim
 
 LABEL maintainer="Florian JUDITH <florian.judith.b@gmail.com>"
 
-ARG VERSION=9.4.6
+ARG VERSION=9.4.7
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
28-NOV-2018: 9.4.7

- Adds multiple page PDF export option
- GraphML import improvements
- Adds addition IBM cloud stencils
- Adds Data Flow Diagram stencils
