### PR TITLE
tomcat:9-jre10-slim no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Supported tags and respective Dockerfile links
 
-[`9.5.1`, `latest`](https://github.com/fjudith/docker-draw.io/tree/9.5.1)
+[`9.6.1`, `latest`](https://github.com/fjudith/docker-draw.io/tree/9.6.1)
 
 # Introduction
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,12 +1,12 @@
-FROM tomcat:9-jre10-slim
+FROM tomcat:9-jre11-slim
 
 LABEL maintainer="Florian JUDITH <florian.judith.b@gmail.com>"
 
-ARG VERSION=9.5.1
+ARG VERSION=9.6.1
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
-        openjdk-10-jdk-headless ant git patch wget xmlstarlet certbot curl && \
+        openjdk-11-jdk-headless ant git patch wget xmlstarlet certbot curl && \
     cd /tmp && \
     wget https://github.com/jgraph/draw.io/archive/v${VERSION}.zip && \
     unzip v${VERSION}.zip && \
@@ -15,7 +15,7 @@ RUN apt-get update -y && \
     ant war && \
     cd /tmp/drawio-${VERSION}/build && \
     unzip /tmp/drawio-${VERSION}/build/draw.war -d $CATALINA_HOME/webapps/draw && \
-    apt-get remove -y --purge openjdk-10-jdk-headless ant git patch wget && \
+    apt-get remove -y --purge openjdk-11-jdk-headless ant git patch wget && \
     apt-get autoremove -y --purge && \
     apt-get clean && \
     rm -r /var/lib/apt/lists/* && \


### PR DESCRIPTION
Looks like debian removed some packages


[https://github.com/docker-library/tomcat/issues/138](https://github.com/docker-library/tomcat/issues/138)
[https://github.com/docker-library/openjdk/pull/254](https://github.com/docker-library/openjdk/pull/254)
[https://github.com/docker-library/tomcat/tree/master/9.0](https://github.com/docker-library/tomcat/tree/master/9.0)