### PR TITLE
Add Runme button to demonstrate the latest version of application

### DIFF
--- a/.runme/config.yaml
+++ b/.runme/config.yaml
@@ -1,0 +1,8 @@
+version: 1.0
+publish: app
+services:
+  app:
+    image: fjudith/draw.io:latest
+    ports:
+    - container: 8080
+      public: 80

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Get your own image badge on microbadger.com](https://images.microbadger.com/badges/image/fjudith/draw.io.svg)](https://microbadger.com/images/fjudith/draw.io)
 [![Build Status](https://travis-ci.org/fjudith/docker-draw.io.svg?branch=master)](https://travis-ci.org/fjudith/docker-draw.io)
 [![Docker Repository on Quay](https://quay.io/repository/fjudith/draw.io/status "Docker Repository on Quay")](https://quay.io/repository/fjudith/draw.io)
+[![Runme](https://svc.runme.io/static/button.svg)](https://runme.io/run?app_id=825de29f-c507-49dd-ab0e-2ff76211d659)
 
 [latest](https://github.com/fjudith/docker-draw.io/tree/master/debian)
 [alpine](https://github.com/fjudith/docker-draw.io/tree/master/alpine)


### PR DESCRIPTION
This PR adds Runme button-label [![Runme](https://svc.runme.io/static/button.svg)](https://runme.io/run?app_id=2c5ee7c9-96d2-4a1d-a759-32a639c1de2e) (clickable) to run the project from latest commit with one click.

**How it works:**
1. Runme clones the repository and builds a docker image for latest commit or use already built docker image;
2. deploys the docker image to k8s cluster;
3. creates domain with SSL certificate;
4. shows web application;
5. destroys app instance after 10 minutes.

You can find detailed information how this works [here](https://runme.io/how-it-works). The small demo you can find [here](https://www.youtube.com/channel/UCEysV237wo321JatUTC6Rlg).

**Why do you need this?**
- Runme is perfect solution to demonstrate current state of code/repository, anybody can just click the button and see the state;
- Runme totally free, we love open source projects and want to support them;
- Runme can be used as a tool for preparation docker images with a developer's version of code

**Screenshot**
![result](https://user-images.githubusercontent.com/8326634/83148301-78167b80-a101-11ea-9306-059775ac8a14.png)
